### PR TITLE
Fixed a sytax error in config.pp

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,7 +12,7 @@ define tiller::config (
   $_target_file = "/etc/tiller/environments/${environment}.yaml"
 
   $_config = {
-    $template => {
+    "$template" => {
       target => $target,
       user   => $user,
       group  => $group,


### PR DESCRIPTION
Since `$` is reserved in puppet, there's a need to quote it in order to use it as a hash key.
