### PR TITLE
Update metadata.json to use forward slashes instead of hyphens

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/jfryman/puppet-tiller",
   "issues_url": "https://github.com/jfryman/puppet-tiller/issues",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.0"}
   ]
 }
 


### PR DESCRIPTION
This stops `puppet module list` from giving dependency errors on puppet3.8

Behavior when using hyphens:

```
root@stackstorm:~# puppet module list
Warning: Missing dependency 'puppetlabs-stdlib':
  'jfryman-tiller' (v0.1.0) requires 'puppetlabs-stdlib' (>= 1.0.0)
/etc/puppet/modules
├── garethr-erlang (v0.3.0)
├── ghoneycutt-facter (v3.2.0)
├── hunner-hiera (v2.0.1)
├── jamtur01-httpauth (v0.0.3)
├── jfryman-tiller (v0.1.0)
├── maestrodev-git (v1.0.6)
<snipped>
```

After changing to forward slashes, the warning go's away:

```
root@stackstorm:/etc/puppet/modules/tiller# puppet module list
/etc/puppet/modules
├── garethr-erlang (v0.3.0)
├── ghoneycutt-facter (v3.2.0)
├── hunner-hiera (v2.0.1)
├── jamtur01-httpauth (v0.0.3)
├── jfryman-tiller (v0.1.0)
├── maestrodev-git (v1.0.6)
<snipped>
```
